### PR TITLE
fix: global high resolution timer

### DIFF
--- a/kernel/src/xil/time.rs
+++ b/kernel/src/xil/time.rs
@@ -4,4 +4,5 @@ pub type XTime = u64;
 
 extern "C" {
     pub fn XTime_GetTime(XTime_Global: *mut XTime);
+    pub fn XTime_SetTime(XTime_Global: *mut XTime);
 }


### PR DESCRIPTION
fixes `vexSystemHighResTimeGet` by directly reading the global timer counter register and bypassing XTime, which seemingly had some weirdness resetting after reaching the 16-bit integer limit. Also ensures that the function returns microseconds rather than clocks.