### PR TITLE
fix: add ARM exception vector table and refactor boot routine

### DIFF
--- a/kernel/link/kernel.ld
+++ b/kernel/link/kernel.ld
@@ -1,24 +1,31 @@
-_low_memory_start = 0x100000;
-_cold_memory_start = 0x03800000;
-_jump_table_start = _cold_memory_start - 0x4000;
+OUTPUT_FORMAT("elf32-littlearm")
 
+ENTRY(reset)
+
+_low_memory_start = 0x0;
+_user_memory_start = 0x03800000;
+_jump_table_start = _user_memory_start - 0x4000;
 
 MEMORY {
   low_mem : ORIGIN = _low_memory_start, LENGTH = _jump_table_start - _low_memory_start
-  jump_table_mem (rx) : ORIGIN = _jump_table_start, LENGTH = _cold_memory_start - _jump_table_start
+  jump_table_mem (rx) : ORIGIN = _jump_table_start, LENGTH = _user_memory_start - _jump_table_start
 }
 
+__stack_length = 0x400000;
 /*
 This arbitrary subtraction was pulled from vexide's linker script. The heap is big enough that it
 probably won't be noticeable so I played it safe by keeping the same value.
 */
-__heap_end = _jump_table_start - 0x100;
+__heap_end = _jump_table_start - __stack_length - 0x100;
 
 SECTIONS {
-    _vex_startup = _cold_memory_start + 0x20;
+    _vex_startup = _user_memory_start + 0x20;
 
     .text ALIGN(4096) : {
-        *(.text*)
+        __text_start = .;
+        KEEP (*(.text.vectors))
+        *(.text.boot);
+        *(.text .text*)
     } > low_mem
 
     .rodata ALIGN(4096) : {
@@ -36,6 +43,12 @@ SECTIONS {
     .heap (NOLOAD) : ALIGN(4) {
         __heap_start = .;
         . = __heap_end;
+    } > low_mem
+
+    .stack (NOLOAD) : ALIGN(8) {
+        __stack_bottom = .;
+        . += __stack_length;
+        __stack_top = .;
     } > low_mem
 
     .jump_table : {

--- a/kernel/src/asm.rs
+++ b/kernel/src/asm.rs
@@ -1,0 +1,40 @@
+use core::arch::asm;
+
+/// Sets the value of the VBAR (Vector Base Address Register).
+///
+/// # Safety
+///
+/// This function deals with extremely lowlevel registers that handle interrupts
+/// and system exceptions. Setting vbar to functions that incorrectly handle interrupts
+/// can be catastrophic.
+pub unsafe fn set_vbar(addr: u32) {
+    unsafe { core::arch::asm!("mcr p15, 0, {}, c12, c0, 0", in(reg) addr, options(nomem, nostack)) }
+}
+
+/// Enables access to VFP3 instructions using the Floating Point Unit (FPU)
+pub fn enable_vfp() {
+    unsafe {
+        asm!(
+            "
+            // Read CPACR (Coprocessor Access Control Register)
+            mrc p15, 0x0, r1, c1, c0, 0x2
+
+            // Enable VFP access (Full Access to CP10, CP11) (V* instructions)
+            orr r1, r1, (0b1111 << 20)
+
+            // Write back CPACR (Coprocessor Access Control Register)
+            mcr p15, 0x0, r1, c1, c0, 0x2
+
+            // Read FPEXC (Floating Point Exception Register)
+            vmrs r1, fpexc
+
+            // The EN bit, FPEXC[30], is the VFP enable bit.
+            orr r1, r1, (1 << 30)
+
+            // Write to FPEXC
+            vmsr fpexc, r1
+            ",
+            options(nomem, nostack)
+        );
+    }
+}

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -1,14 +1,14 @@
 #![no_std]
 #![no_main]
-#![feature(c_variadic)]
+#![feature(c_variadic, naked_functions)]
 
-extern crate alloc;
-
+pub mod asm;
 pub mod sdk;
 pub mod xil;
+pub mod vectors;
 
 use core::{
-    arch::global_asm,
+    arch::asm,
     cell::UnsafeCell,
     ffi::c_void,
     sync::atomic::{AtomicU32, Ordering},
@@ -44,7 +44,7 @@ pub static mut WATCHDOG_TIMER: UnsafeCell<XScuWdt> =
 
 pub static SYSTEM_TIME: AtomicU32 = AtomicU32::new(0);
 
-pub unsafe extern "C" fn timer_interrupt_handler(_: *mut c_void) {
+unsafe extern "C" fn timer_interrupt_handler(_: *mut c_void) {
     let timer = unsafe { PRIVATE_TIMER.get_mut() };
 
     if unsafe { XScuTimer_IsExpired(timer) } {
@@ -131,21 +131,42 @@ pub fn setup_gic() {
 }
 
 extern "C" {
-    #[link_name = "_cold_memory_start"]
-    static COLD_MEMORY_START: *const ();
+    // #[link_name = "_user_memory_start"]
+    // static USER_MEMORY_START: *const ();
+
+    #[link_name = "__text_start"]
+    static VECTORS_START: u32;
 
     #[link_name = "_vex_startup"]
     fn vexStartup();
 }
 
-extern "C" fn main() -> ! {
+#[no_mangle]
+pub extern "C" fn reset() -> ! {
+    unsafe {
+        // Install vector table for interrupt handling
+        //
+        // This probably isn't necessary, since I believe that our CPU
+        // will assume that the vector table is located at 0x0.
+        //
+        // See: <https://developer.arm.com/documentation/ddi0406/b/System-Level-Architecture/The-System-Level-Programmers--Model/Exceptions/Exception-vectors-and-the-exception-base-address>
+        asm::set_vbar(VECTORS_START);
+
+        // Enable FPU
+        asm::enable_vfp();
+
+        // Setup the stack pointer
+        asm!("ldr sp, =__stack_top");
+
+        // TODO: look into playing with l2 cache
+        // See: <https://git.m-labs.hk/M-Labs/zynq-rs/src/branch/master/experiments/src/main.rs
+
+        // Normally, startup code would clear .bss around here, but VEX
+        // doesn't do that so we won't either :D
+    }
+
     setup_gic();
     setup_timer();
-    // SAFETY: This is the first time this function is called and __heap_start
-    // and __heap_end are correctly set by the linker script.
-    unsafe {
-        vexide_core::allocator::vexos::init_heap();
-    }
 
     semihosting::println!("Starting robot code");
 
@@ -155,23 +176,3 @@ extern "C" fn main() -> ! {
 
     unreachable!("vexStartup should not return!");
 }
-
-// Load the stack, setup entrypoint, enable FPU.
-global_asm!(
-    r#"
-        .section .text
-        .global _start
-        .type _start, STT_FUNC
-
-    _start:
-        ldr sp, =0x10000
-        mrc p15, 0x0, r1, c1, c0, 0x2
-        orr r1, r1, #0xf00000
-        mcr p15, 0x0, r1, c1, c0, 0x2
-        mrc p10, 0x7, r1, c8, c0, 0x0
-        orr r1, r1, #0x40000000
-        mcr p10, 0x7, r1, c8, c0, 0x0
-        b {main}
-    "#,
-    main = sym main
-);

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -163,6 +163,8 @@ pub extern "C" fn reset() -> ! {
 
         // Normally, startup code would clear .bss around here, but VEX
         // doesn't do that so we won't either :D
+
+        vexide_core::allocator::vexos::init_heap();
     }
 
     setup_gic();

--- a/kernel/src/sdk/mod.rs
+++ b/kernel/src/sdk/mod.rs
@@ -474,6 +474,8 @@ pub static mut JUMP_TABLE: [*const (); 0x1000] = {
     table
 };
 
-pub unsafe extern "C" fn unshimmed_syscall() -> ! {
-    loop {}
+pub extern "C" fn unshimmed_syscall() -> ! {
+    loop {
+        core::hint::spin_loop();
+    }
 }

--- a/kernel/src/sdk/system.rs
+++ b/kernel/src/sdk/system.rs
@@ -196,12 +196,21 @@ pub fn vexSystemWatchdogGet() -> u32 {
 }
 pub fn vexSystemBoot() {}
 
-// TODO: Register these as exception handlers for ARM stuff so we
-// get some sort of feedback if one occurs and not just a pc jump
-// to 0x10.
-pub fn vexSystemUndefinedException() {}
-pub fn vexSystemFIQInterrupt() {}
-pub fn vexSystemIQRQnterrupt() {}
-pub fn vexSystemSWInterrupt() {}
-pub fn vexSystemDataAbortInterrupt() {}
-pub fn vexSystemPrefetchAbortInterrupt() {}
+pub fn vexSystemUndefinedException() {
+    semihosting::println!("Undefined Instruction Exception");
+}
+pub fn vexSystemFIQInterrupt() {
+    semihosting::println!("FIQ");
+}
+pub fn vexSystemIQRQnterrupt() {
+    semihosting::println!("IRQ");
+}
+pub fn vexSystemSWInterrupt() {
+    semihosting::println!("Software Interrupt");
+}
+pub fn vexSystemDataAbortInterrupt() {
+    semihosting::println!("Data Abort Exception");
+}
+pub fn vexSystemPrefetchAbortInterrupt() {
+    semihosting::println!("Prefetch Abort Exception");
+}

--- a/kernel/src/vectors.rs
+++ b/kernel/src/vectors.rs
@@ -1,0 +1,153 @@
+//! CPU Exception Vectors
+//!
+//! This module contains implementations of each ARM exception vector
+//! required to handle exceptions (including interrupts) in `vectors.s`.
+//!
+//! This file does not include the `reset` vector (entrypoint), which can be
+//! found in `main.rs`.
+//!
+//! In most cases, these functions are implemented from Xilinx's `asm_vectors.s`
+//! file: <https://github.com/Xilinx/embeddedsw/blob/5688620af40994a0012ef5db3c873e1de3f20e9f/lib/bsp/standalone/src/arm/cortexa9/armcc/asm_vectors.s>
+
+use core::arch::{asm, global_asm};
+
+use vex_sdk::{vexSystemDataAbortInterrupt, vexSystemFIQInterrupt, vexSystemPrefetchAbortInterrupt};
+
+// Include the vector table
+global_asm!(include_str!("vectors.s"));
+
+/// Undefined Instruction Vector
+///
+/// This function is jumped to when the CPU when pc runs into an undefined instruction. It
+/// currently just saves the program state/registers and calls `UndefinedException` from libxil.
+///
+/// This exception occurs when the CPU's instruction pipelining encounters and attempts to
+/// execute an instrction it does not recognize.
+#[no_mangle]
+#[naked]
+pub extern "C" fn undefined_instruction() -> ! {
+    unsafe {
+        asm!(
+            "
+            stmdb sp!,{{r0-r3,r12,lr}} // state save from compiled code
+            ldr r0, =UndefinedExceptionAddr
+            sub r1, lr,#4
+            str r1, [r0] // Address of instruction causing undefined exception
+            bl UndefinedException // UndefinedException: call C function here
+            ldmia sp!, {{r0-r3,r12,lr}} // state restore from compiled code
+
+            movs pc, lr
+            ",
+            options(noreturn)
+        )
+    }
+}
+
+/// Software Interrupt Vector
+///
+/// This function is jumped to when the CPU recieves a software interrupt (SWI/SVC). It
+/// currently just saves the program state/registers and calls `SWInterrupt` from libxil.
+#[no_mangle]
+#[naked]
+pub extern "C" fn svc() -> ! {
+    unsafe {
+        asm!(
+            "
+            stmdb sp!,{{r0-r3,r12,lr}} // state save from compiled code
+            tst	r0, #0x20 // check the T bit
+            // ldrneh r0, [lr,#-2] // Thumb mode
+            // bicne r0, r0, #0xff00 // Thumb mode
+            ldreq r0, [lr,#-4] // ARM mode
+            biceq r0, r0, #0xff000000 // ARM mode
+            bl SWInterrupt // SWInterrupt: call C function here
+            ldmia sp!,{{r0-r3,r12,lr}} // state restore from compiled code
+            movs pc, lr // adjust return
+            ",
+            options(noreturn)
+        )
+    }
+}
+
+/// Prefetch Abort Vector
+///
+/// This function is jumped to by the CPU when a prefetch abort (PABT) occurs.
+///
+/// Prefetch aborts occur when instruction pipelining is unable to fetch an
+/// instruction, then proceeds to attempt to execute at that location.
+///
+/// See: <https://developer.arm.com/documentation/ddi0406/b/System-Level-Architecture/The-System-Level-Programmers--Model/Exceptions/Prefetch-Abort-exception>
+#[no_mangle]
+pub extern "C" fn prefetch_abort() -> ! {
+    // TODO: copy <https://github.com/Xilinx/embeddedsw/blob/5688620af40994a0012ef5db3c873e1de3f20e9f/lib/bsp/standalone/src/arm/cortexa9/armcc/asm_vectors.s#L133>
+    // rather than just calling the jumptable function. This should first go through libxil, then libxil should
+    // call vexSystemPrefetchAbortInterrupt.
+    unsafe {
+        vexSystemPrefetchAbortInterrupt();
+    }
+    semihosting::process::exit(1);
+}
+
+/// Data Abort Vector
+///
+/// This function is jumped to by the CPU when a data abort occurs.
+///
+/// Data aborts typically occur as a result of illegal memory accesses.
+///
+/// See: <https://developer.arm.com/documentation/ddi0406/b/System-Level-Architecture/The-System-Level-Programmers--Model/Exceptions/Data-Abort-exception>
+#[no_mangle]
+pub extern "C" fn data_abort() -> ! {
+    // TODO: copy <https://github.com/Xilinx/embeddedsw/blob/5688620af40994a0012ef5db3c873e1de3f20e9f/lib/bsp/standalone/src/arm/cortexa9/armcc/asm_vectors.s#L124>
+    // rather than just calling the jumptable function. This should first go through libxil, then libxil should
+    // call vexSystemDataAbortInterrupt.
+    unsafe {
+        vexSystemDataAbortInterrupt();
+    }
+    semihosting::process::exit(1);
+}
+
+/// Interrupt Request Vector
+///
+/// This function is jumped to when the CPU recieves an IRQ. It currently just saves the
+/// program state/registers and calls `IRQInterrupt` from libxil.
+#[no_mangle]
+#[naked]
+pub extern "C" fn irq() -> ! {
+    unsafe {
+        asm!(
+            "
+                stmdb sp!,{{r0-r3,r12,lr}} // state save from compiled code
+                vpush {{d0-d7}}
+                vpush {{d16-d31}}
+                vmrs r1, FPSCR
+                push {{r1}}
+                vmrs r1, FPEXC
+                push {{r1}}
+                bl IRQInterrupt // IRQ vector
+                pop {{r1}}
+                vmsr FPEXC, r1
+                pop {{r1}}
+                vmsr FPSCR, r1
+                vpop {{d16-d31}}
+                vpop {{d0-d7}}
+                ldmia sp!,{{r0-r3,r12,lr}} // state restore from compiled code
+                subs pc, lr, #4 // adjust return
+            ",
+            options(noreturn)
+        )
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn fiq() -> ! {
+    // TODO: look at <https://github.com/Xilinx/embeddedsw/blob/5688620af40994a0012ef5db3c873e1de3f20e9f/lib/bsp/standalone/src/arm/cortexa9/armcc/asm_vectors.s#L82>
+    //
+    // This one's also a little weird since there's an FIQLoop symbol, where I have no idea
+    // if or when its ever called or used here. Either way, FIQs aren't ever used on the V5.
+    unsafe {
+        vexSystemFIQInterrupt();
+    }
+
+    loop {
+        core::hint::spin_loop();
+    }
+}

--- a/kernel/src/vectors.s
+++ b/kernel/src/vectors.s
@@ -1,0 +1,12 @@
+.section ".text.vectors"
+.global vectors
+
+vectors:
+    b reset
+    b undefined_instruction
+    b software_interrupt
+    b prefetch_abort
+    b data_abort
+    nop // Placeholder for address exception vector
+    b irq
+    b fiq


### PR DESCRIPTION
Fixes PROS programs which use some interrupts before overwriting `vbar` with their own FreeRTOS vector table and makes our boot process more "correct", since we were previously just incapable of handling IRQs.

There are still more things to look into in this area, like setting up L2 cache (see the comment in `main.rs`) and wiring up the jumptable's exception handlers through libxil.